### PR TITLE
Fixes README.md reference to sample.

### DIFF
--- a/R/get_king_pit.R
+++ b/R/get_king_pit.R
@@ -3,7 +3,12 @@ library(rio)
 
 # globalVariables hack that avoids "Notes" from being issued
 # by devtools::check().
-# See: https://stackoverflow.com/questions/9439256/how-can-i-handle-r-cmd-check-no-visible-binding-for-global-variable-notes-when
+# See:
+# https://stackoverflow.com/questions/9439256/how-can-i-handle-r-cmd-check-no-visible-binding-for-global-variable-notes-when
+# for the solution recommended by Hadley Wickham, which we follow here.
+# But see:
+# https://nathaneastwood.github.io/2019/08/18/no-visible-binding-for-global-variable/
+# for alternative solutions.
 utils::globalVariables("%>%")
 utils::globalVariables(c(
   "year",

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ These examples can help you start analyzing the data:
 
   * Hosted [burro](https://laderast.github.io/burro/) demo: [Browse King County evictions data](https://tladeras.shinyapps.io/evictions_king_county/).
   * [Run burro in your local environment](vignettes/evictions.Rmd).
-  * [Introduction to Geospatial Visualization](vignettes/Introduction_to_Visualizing_Geospatial_Data.md) for the King County data.
+  * [Introduction to Geospatial Visualization](vignettes/Introduction-to-Visualizing-Geospatial-Data.md) for the King County data.
   * [Read data from the `oneNightCount.csv` file](vignettes/demo-1night-vroom-etc.md) with [vroom](https://cran.r-project.org/package=vroom) and summarize the contents with [skimr](https://cran.r-project.org/package=skimr) and [inspectdf](https://cran.r-project.org/package=inspectdf).
 
 ## Notes and resources

--- a/vignettes/Introduction-to-Visualizing-Geospatial-Data.Rmd
+++ b/vignettes/Introduction-to-Visualizing-Geospatial-Data.Rmd
@@ -33,6 +33,9 @@ library(stringr)
 library(sf)  # working with spatial data
 library(mapview)  # quick and easy geospatial visualizations
 library(tigris)  # downloading geospatial data from the census
+
+# data package
+library(craggy2019)
 ```
 
 To start I will read the evictions data into memory. The data is stored in a csv so I will use `read.csv()` to read the data and assign the data frame to evictions. After reading the data into memory I will print the first five rows.

--- a/vignettes/Introduction-to-Visualizing-Geospatial-Data.md
+++ b/vignettes/Introduction-to-Visualizing-Geospatial-Data.md
@@ -1,7 +1,7 @@
 Introduction to Geospatial Visualization
 ================
 [Marley Buchman](https://github.com/buchmayne)
-2019-08-23
+2019-08-24
 
 In preparation for craggy 2019, here is a very brief introduction to
 simple ways to visualize spatial data. This notebook will introduce some
@@ -38,6 +38,9 @@ library(stringr)
 library(sf)  # working with spatial data
 library(mapview)  # quick and easy geospatial visualizations
 library(tigris)  # downloading geospatial data from the census
+
+# data package
+library(craggy2019)
 ```
 
 To start I will read the evictions data into memory. The data is stored

--- a/vignettes/demo-1night-vroom-etc.Rmd
+++ b/vignettes/demo-1night-vroom-etc.Rmd
@@ -24,6 +24,7 @@ library(vroom)
 library(inspectdf)
 library(skimr)
 library(janitor)
+library(craggy2019)
 ```
 Generate a minimally serviceable data frame:
 ```{r}

--- a/vignettes/demo-1night-vroom-etc.md
+++ b/vignettes/demo-1night-vroom-etc.md
@@ -1,19 +1,20 @@
 Demo OneNightCount.csv and vroom
 ================
 [John D. Smith](https://github.com/smithjd/)
-2019-08-23
+2019-08-24
 
 ``` r
 library(tidyverse)
 ```
 
-    ## ── Attaching packages ─────── tidyverse 1.2.1 ──
+    ## ── Attaching packages ────── tidyverse 1.2.1 ──
 
-    ## ✔ tibble  2.1.3     ✔ readr   1.3.1
-    ## ✔ tidyr   0.8.3     ✔ purrr   0.3.2
-    ## ✔ tibble  2.1.3     ✔ forcats 0.4.0
+    ## ✔ ggplot2 3.2.1     ✔ readr   1.3.1
+    ## ✔ tibble  2.1.3     ✔ purrr   0.3.2
+    ## ✔ tidyr   0.8.3     ✔ stringr 1.4.0
+    ## ✔ ggplot2 3.2.1     ✔ forcats 0.4.0
 
-    ## ── Conflicts ────────── tidyverse_conflicts() ──
+    ## ── Conflicts ───────── tidyverse_conflicts() ──
     ## ✖ dplyr::filter() masks stats::filter()
     ## ✖ dplyr::lag()    masks stats::lag()
 
@@ -40,6 +41,10 @@ library(janitor)
     ## The following objects are masked from 'package:stats':
     ## 
     ##     chisq.test, fisher.test
+
+``` r
+library(craggy2019)
+```
 
 Generate a minimally serviceable data frame:
 
@@ -72,11 +77,11 @@ skim(oneNightCount)
     ##  n obs: 120 
     ##  n variables: 13 
     ## 
-    ## ── Variable type:character ─────────────────────
+    ## ── Variable type:character ────────────────────
     ##  variable missing complete   n min max empty n_unique
     ##  location       0      120 120   5  18     0       12
     ## 
-    ## ── Variable type:numeric ───────────────────────
+    ## ── Variable type:numeric ──────────────────────
     ##         variable missing complete   n    mean     sd   p0  p25    p50
     ##           auburn      12      108 120    5.88  11.67    0    0    1  
     ##        east_side       0      120 120   13.48  24.72    0    0    3  

--- a/vignettes/evictions.Rmd
+++ b/vignettes/evictions.Rmd
@@ -20,6 +20,10 @@ Run this code block to install `burro` (Data exploration app)
 ```{r eval=FALSE}
 install.packages("remotes")
 remotes::install_github("laderast/burro")
+
+# Install from the source repository,
+# if you are not running in a fork of the craggy2019 project.
+# remotes::install_github("pdxrlang/craggy_2019")
 ```
 
 Once installed, run from here on...
@@ -30,6 +34,7 @@ library(burro)
 library(tidyr)
 library(dplyr)
 library(janitor)
+library(craggy2019)
 ```
 
 ## Looking at the `evictions` dataset

--- a/vignettes/evictions.md
+++ b/vignettes/evictions.md
@@ -1,7 +1,7 @@
 Looking at Evictions
 ================
 [Ted Laderas](https://github.com/laderast)
-2019-08-23
+2019-08-24
 
   - [Looking at the `evictions`
     dataset](#looking-at-the-evictions-dataset)
@@ -17,6 +17,10 @@ Run this code block to install `burro` (Data exploration app)
 ``` r
 install.packages("remotes")
 remotes::install_github("laderast/burro")
+
+# Install from the source repository,
+# if you are not running in a fork of the craggy2019 project.
+# remotes::install_github("pdxrlang/craggy_2019")
 ```
 
 Once installed, run from here on…
@@ -46,7 +50,7 @@ burro::explore_data(evictions)
     ## locale to "Chinese" cannot be honored
 
     ## 
-    ## Listening on http://127.0.0.1:8590
+    ## Listening on http://127.0.0.1:6180
 
 ![](evictions_files/figure-gfm/unnamed-chunk-2-1.png)<!-- -->
 
@@ -107,7 +111,7 @@ burro::explore_data(forclose_wa)
     ## locale to "Chinese" cannot be honored
 
     ## 
-    ## Listening on http://127.0.0.1:4638
+    ## Listening on http://127.0.0.1:7470
 
 ![](evictions_files/figure-gfm/unnamed-chunk-3-1.png)<!-- -->
 
@@ -153,7 +157,7 @@ burro::explore_data(one_night)
     ## locale to "Chinese" cannot be honored
 
     ## 
-    ## Listening on http://127.0.0.1:5363
+    ## Listening on http://127.0.0.1:5680
 
 ![](evictions_files/figure-gfm/unnamed-chunk-5-1.png)<!-- -->
 


### PR DESCRIPTION
* Fixes README.md reference to `Introduction-to-Visualizing-Geospatial-Data.md` sample.
*  Loads  `craggy2019` package in Rmd files. The code worked fine before, because I was working in the `craggy2019` package source code directory and I was building the package to generate the vignettes. However, this change is needed for people developing in their own project, who might copy and past the Rmd file without working within the `pdxrlang/craggy_2019` project. By adding the `library(craggy2019)` calls, the code will still work when executed outside of this `pdxrlang/craggy_2019` project.